### PR TITLE
Result -- add unwrapOrThrow method

### DIFF
--- a/src/main/java/org/farwind/util/Result.java
+++ b/src/main/java/org/farwind/util/Result.java
@@ -147,6 +147,17 @@ public abstract class Result<T, E extends Throwable> {
     abstract T unwrapOrElse(Function<E,T> op);
 
     /**
+     * If {@link Ok}, returns the contained value, otherwise throws the
+     * current error. This method provides a transition from the stream
+     * and functional exception pattern back to the imperative exception
+     * handling pattern.
+     *
+     * @return The contained value if {@link Ok}
+     * @throws <E> The contained error if {@link Err}.
+     */
+    abstract T unwrapOrThrow() throws E;
+
+    /**
      * if {@link Ok}, returns the contained value, otherwise throws a
      * {@link NoSuchElementException}.
      *
@@ -247,6 +258,11 @@ public abstract class Result<T, E extends Throwable> {
         }
 
         @Override
+        public T unwrapOrThrow() throws E {
+            return t;
+        }
+
+        @Override
         public T unwrap() {
             return t;
         }
@@ -337,6 +353,11 @@ public abstract class Result<T, E extends Throwable> {
         @Override
         public T unwrapOrElse(Function<E,T> op) {
             return op.apply(e);
+        }
+
+        @Override
+        public T unwrapOrThrow() throws E {
+            throw e;
         }
 
         @Override

--- a/src/test/java/org/farwind/util/ErrTest.java
+++ b/src/test/java/org/farwind/util/ErrTest.java
@@ -116,6 +116,11 @@ public class ErrTest {
                 new Err<>(new TestException1()).unwrapOrElse(Object::getClass));
     }
 
+    @Test(expected = TestException1.class)
+    public void unwrapOrThrow() throws Exception {
+        new Err<>(new TestException1()).unwrapOrThrow();
+    }
+
     @Test(expected = NoSuchElementException.class)
     public void unwrap() throws Exception {
         new Err<>(new TestException1()).unwrap();

--- a/src/test/java/org/farwind/util/OkTest.java
+++ b/src/test/java/org/farwind/util/OkTest.java
@@ -129,6 +129,12 @@ public class OkTest {
     }
 
     @Test
+    public void unwrapOrThrow() throws Exception {
+        Result<String, TestException1> res = new Ok<>("this is okay");
+        assertEquals("this is okay", res.unwrapOrThrow());
+    }
+
+    @Test
     public void unwrap() throws Exception {
         Result<String, TestException1> res = new Ok<>("this is okay");
         assertEquals("this is okay", res.unwrap());


### PR DESCRIPTION
added unwrapOrThrow method to provide a transition for the Result error handling pattern back to the imperative exception throwing pattern. resolves #4 